### PR TITLE
Rewards layout

### DIFF
--- a/sprinkle-sprite/src/app/app.routes.ts
+++ b/sprinkle-sprite/src/app/app.routes.ts
@@ -15,6 +15,7 @@ export const routes: Routes = [
       { path: 'menu', component: MenuComponent },
       { path: 'checkout', component: CheckoutComponent },
       { path: 'account', component: AccountComponent },
+
     ],
   },
   {

--- a/sprinkle-sprite/src/app/app.routes.ts
+++ b/sprinkle-sprite/src/app/app.routes.ts
@@ -18,15 +18,10 @@ export const routes: Routes = [
 
     ],
   },
-  {
-    path: 'login',
-    loadComponent: () =>
-      import('./login/login.component').then((m) => m.LoginComponent),
+  { path: 'login', loadComponent: () => import('./login/login.component').then((m) => m.LoginComponent),
   },
-  {
-    path: 'create-account',
-    loadComponent: () =>
-      import('./create-user/create-user.component').then(m => m.CreateUserComponent)
+  { path: 'create-account', loadComponent: () => import('./create-user/create-user.component').then(m => m.CreateUserComponent)
   },
+  { path: 'vip-rewards', loadComponent: () => import('./rewards/vip-rewards.component').then(m => m.VipRewardsComponent) },
 
 ];

--- a/sprinkle-sprite/src/app/layout/main/mainbody/pov/account/account.component.html
+++ b/sprinkle-sprite/src/app/layout/main/mainbody/pov/account/account.component.html
@@ -19,7 +19,7 @@
       ADDRESS
     </button>
 
-    <button class="account-button">
+    <button class="account-button" (click)="goToVip()">
       <img src="assets/resources/icons/vip.png" alt="VIP" />
       VIP MEMBERSHIP
     </button>

--- a/sprinkle-sprite/src/app/layout/main/mainbody/pov/account/account.component.ts
+++ b/sprinkle-sprite/src/app/layout/main/mainbody/pov/account/account.component.ts
@@ -13,4 +13,8 @@ export class AccountComponent {
 goToLogin() {
   this.router.navigate(['/login']);
 }
+
+goToVip() {
+  this.router.navigate(['/vip-rewards']);
+}
 }

--- a/sprinkle-sprite/src/app/rewards/vip-rewards.component.css
+++ b/sprinkle-sprite/src/app/rewards/vip-rewards.component.css
@@ -4,7 +4,10 @@
 .vip-hero {
   text-align: center;
   padding: 2rem;
-  background: linear-gradient(to right, #c6f0f2, #1B4568);
+  background: linear-gradient(to right, #c6f0f2, #d03eed);
+  color: #1B4568;
+  border: 3px solid #2b2b2b;
+  box-shadow: 4px 4px #2b2b2b;
 
 }
 
@@ -13,6 +16,7 @@
 .how-to-earn {
   padding: 1.5rem;
   background-color: #F3C5FF;
+  color: #1B4568;
 }
 
 .rarity-grid,
@@ -22,6 +26,7 @@
   gap: 1.5rem;
   justify-content: center;
   background-color: #F3C5FF;
+  color: #1B4568;
 
 }
 
@@ -29,8 +34,8 @@
 .loyalty-card {
   background: #fff3eb;
   padding: 1rem 1.5rem;
-  box-shadow: 0 4px 12px rgba(0,0,0,0.1);
   width: 200px;
+  color: #1B4568;
   text-align: center;
   border: 3px solid #2b2b2b;
   box-shadow: 4px 4px #2b2b2b;
@@ -65,12 +70,13 @@
 .menu-btn {
   padding: 1rem 2rem;
   background: #8DF7EB;
-  color: black;
   font-weight: bold;
   font-size: 1.1rem;
   border: none;
-  cursor: pointer;
   transition: transform 0.2s ease;
+  color: #1B4568;
+  border: 3px solid #2b2b2b;
+  box-shadow: 4px 4px #2b2b2b;
 }
 
 .menu-btn:hover {

--- a/sprinkle-sprite/src/app/rewards/vip-rewards.component.css
+++ b/sprinkle-sprite/src/app/rewards/vip-rewards.component.css
@@ -1,0 +1,78 @@
+:host  {
+  background-color: #F3C5FF;
+}
+.vip-hero {
+  text-align: center;
+  padding: 2rem;
+  background: linear-gradient(to right, #c6f0f2, #1B4568);
+
+}
+
+.rarity-section,
+.loyalty-section,
+.how-to-earn {
+  padding: 1.5rem;
+  background-color: #F3C5FF;
+}
+
+.rarity-grid,
+.loyalty-grid {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 1.5rem;
+  justify-content: center;
+  background-color: #F3C5FF;
+
+}
+
+.rarity-card,
+.loyalty-card {
+  background: #fff3eb;
+  padding: 1rem 1.5rem;
+  box-shadow: 0 4px 12px rgba(0,0,0,0.1);
+  width: 200px;
+  text-align: center;
+  border: 3px solid #2b2b2b;
+  box-shadow: 4px 4px #2b2b2b;
+}
+
+.rarity-label {
+  font-weight: bold;
+  font-size: 1.1rem;
+}
+
+.rarity-xp {
+  margin-top: 0.5rem;
+  color: #10b981;
+  font-weight: bold;
+}
+
+.how-to-earn ul {
+  list-style: none;
+  padding: 0;
+}
+
+.how-to-earn li {
+  margin-bottom: 0.5rem;
+}
+
+.cta {
+  text-align: center;
+  padding: 2rem;
+  background-color: #F3C5FF;
+}
+
+.menu-btn {
+  padding: 1rem 2rem;
+  background: #8DF7EB;
+  color: black;
+  font-weight: bold;
+  font-size: 1.1rem;
+  border: none;
+  cursor: pointer;
+  transition: transform 0.2s ease;
+}
+
+.menu-btn:hover {
+  transform: scale(1.05);
+}

--- a/sprinkle-sprite/src/app/rewards/vip-rewards.component.html
+++ b/sprinkle-sprite/src/app/rewards/vip-rewards.component.html
@@ -12,3 +12,12 @@
   }
 </ul>
 
+<h2>🧪 Rarity Test</h2>
+
+<ul>
+  @for (rarity of rarities(); track rarity.id) {
+    <li>
+      <strong>{{ rarity.label }}</strong> – {{ rarity.xp_value }} XP
+    </li>
+  }
+</ul>

--- a/sprinkle-sprite/src/app/rewards/vip-rewards.component.html
+++ b/sprinkle-sprite/src/app/rewards/vip-rewards.component.html
@@ -1,23 +1,55 @@
-<h2>🔥 Debug Loyalty Data</h2>
-
-<ul>
-  @for (level of loyaltyLevels(); track level.level_name) {
-  <li>
-    <strong>{{ level.level_name }}</strong> –
-    {{ level.points_required }} XP –
-    {{ level.reward_description }}
-  </li>
 
 
-  }
-</ul>
+<!-- 🌟 Section 1: Hero Intro -->
+<section class="vip-hero">
+  <h1>🎖️ Become a Sprinkle Sprite VIP!</h1>
+  <p>
+    Earn XP from every scoop you buy. The rarer the flavor, the more you earn.
+    Climb the VIP ranks and unlock exclusive rewards along the way!
+  </p>
+</section>
 
-<h2>🧪 Rarity Test</h2>
+<!-- 🍦 Section 2: Rarity XP Chart -->
+<section class="rarity-section">
+  <h2>🍦 XP by Flavor Rarity</h2>
+  <div class="rarity-grid">
+    @for (rarity of rarities(); track rarity.id) {
+      <div class="rarity-card">
+        <div class="rarity-label">{{ rarity.label }}</div>
+        <div class="rarity-xp">+{{ rarity.xp_value }} XP</div>
+      </div>
+    }
+  </div>
+</section>
 
-<ul>
-  @for (rarity of rarities(); track rarity.id) {
-    <li>
-      <strong>{{ rarity.label }}</strong> – {{ rarity.xp_value }} XP
-    </li>
-  }
-</ul>
+<!-- 🏆 Section 3: Loyalty Tier Cards -->
+<section class="loyalty-section">
+  <h2>🌟 VIP Loyalty Levels</h2>
+  <div class="loyalty-grid">
+    @for (level of loyaltyLevels(); track level.level_name) {
+      <div class="loyalty-card">
+        <h3>{{ level.level_name }}</h3>
+        <p><strong>{{ level.points_required }} XP</strong></p>
+        <p>{{ level.reward_description }}</p>
+      </div>
+    }
+  </div>
+</section>
+
+<!-- 🧠 Section 4: How to Earn (Informational) -->
+<section class="how-to-earn">
+  <h2>🧠 How to Earn XP</h2>
+  <ul>
+    <li>🎯 Purchase any ice cream scoop</li>
+    <li>💎 Choose rare or seasonal flavors</li>
+    <li>🔥 Join double XP events when available</li>
+    <li>🎉 Enjoy exclusive flavors during holidays</li>
+  </ul>
+</section>
+
+<!-- 🍨 Section 5: Call to Action -->
+<section class="cta">
+  <button routerLink="/menu" class="menu-btn">
+    🍨 View the Menu & Start Earning
+  </button>
+</section>

--- a/sprinkle-sprite/src/app/rewards/vip-rewards.component.html
+++ b/sprinkle-sprite/src/app/rewards/vip-rewards.component.html
@@ -1,0 +1,1 @@
+<p>vip-rewards works!</p>

--- a/sprinkle-sprite/src/app/rewards/vip-rewards.component.html
+++ b/sprinkle-sprite/src/app/rewards/vip-rewards.component.html
@@ -1,1 +1,14 @@
-<p>vip-rewards works!</p>
+<h2>🔥 Debug Loyalty Data</h2>
+
+<ul>
+  @for (level of loyaltyLevels(); track level.level_name) {
+  <li>
+    <strong>{{ level.level_name }}</strong> –
+    {{ level.points_required }} XP –
+    {{ level.reward_description }}
+  </li>
+
+
+  }
+</ul>
+

--- a/sprinkle-sprite/src/app/rewards/vip-rewards.component.ts
+++ b/sprinkle-sprite/src/app/rewards/vip-rewards.component.ts
@@ -1,4 +1,5 @@
-import { Component } from '@angular/core';
+import { Component, inject } from '@angular/core';
+import { ShopService } from '../sharedservices/shop.service';
 
 @Component({
   selector: 'app-vip-rewards',
@@ -7,5 +8,6 @@ import { Component } from '@angular/core';
   styleUrl: './vip-rewards.component.css'
 })
 export class VipRewardsComponent {
-
+  private shop = inject(ShopService);
+  loyaltyLevels = this.shop.loyaltyLevels;
 }

--- a/sprinkle-sprite/src/app/rewards/vip-rewards.component.ts
+++ b/sprinkle-sprite/src/app/rewards/vip-rewards.component.ts
@@ -1,11 +1,12 @@
 import { Component, inject } from '@angular/core';
 import { ShopService } from '../sharedservices/shop.service';
 import { CommonModule } from '@angular/common';
+import { RouterModule } from '@angular/router';
 
 
 @Component({
   selector: 'app-vip-rewards',
-  imports: [CommonModule],
+  imports: [CommonModule, RouterModule],
   templateUrl: './vip-rewards.component.html',
   styleUrl: './vip-rewards.component.css'
 })

--- a/sprinkle-sprite/src/app/rewards/vip-rewards.component.ts
+++ b/sprinkle-sprite/src/app/rewards/vip-rewards.component.ts
@@ -12,6 +12,6 @@ import { RouterModule } from '@angular/router';
 })
 export class VipRewardsComponent {
   private shop = inject(ShopService);
-  loyaltyLevels = this.shop.loyaltyLevels;
+  loyaltyLevels = this.shop.sortedLoyaltyLevels;
   rarities = this.shop.sortedRarities;
 }

--- a/sprinkle-sprite/src/app/rewards/vip-rewards.component.ts
+++ b/sprinkle-sprite/src/app/rewards/vip-rewards.component.ts
@@ -12,4 +12,5 @@ import { CommonModule } from '@angular/common';
 export class VipRewardsComponent {
   private shop = inject(ShopService);
   loyaltyLevels = this.shop.loyaltyLevels;
+  rarities = this.shop.sortedRarities;
 }

--- a/sprinkle-sprite/src/app/rewards/vip-rewards.component.ts
+++ b/sprinkle-sprite/src/app/rewards/vip-rewards.component.ts
@@ -1,0 +1,11 @@
+import { Component } from '@angular/core';
+
+@Component({
+  selector: 'app-vip-rewards',
+  imports: [],
+  templateUrl: './vip-rewards.component.html',
+  styleUrl: './vip-rewards.component.css'
+})
+export class VipRewardsComponent {
+
+}

--- a/sprinkle-sprite/src/app/rewards/vip-rewards.component.ts
+++ b/sprinkle-sprite/src/app/rewards/vip-rewards.component.ts
@@ -1,9 +1,11 @@
 import { Component, inject } from '@angular/core';
 import { ShopService } from '../sharedservices/shop.service';
+import { CommonModule } from '@angular/common';
+
 
 @Component({
   selector: 'app-vip-rewards',
-  imports: [],
+  imports: [CommonModule],
   templateUrl: './vip-rewards.component.html',
   styleUrl: './vip-rewards.component.css'
 })

--- a/sprinkle-sprite/src/app/sharedservices/shop.service.ts
+++ b/sprinkle-sprite/src/app/sharedservices/shop.service.ts
@@ -48,6 +48,12 @@ export class ShopService {
   }) as Observable<Rarity[]>
 );
 
+  // This sorts the loyalty levels by xp
+  readonly sortedLoyaltyLevels = computed(() => {
+  const all = this.loyaltyLevels();
+  return [...(all ?? [])].sort((a, b) => a.points_required - b.points_required);
+});
+
 //This sorts the rarities list
   readonly sortedRarities = computed(() => {
   const all = this.rarities();

--- a/sprinkle-sprite/src/app/sharedservices/shop.service.ts
+++ b/sprinkle-sprite/src/app/sharedservices/shop.service.ts
@@ -1,7 +1,21 @@
-import { Injectable } from '@angular/core';
+import { Injectable, inject, signal } from '@angular/core';
+import { Firestore, collection, collectionData } from '@angular/fire/firestore';
+import { toSignal } from '@angular/core/rxjs-interop';
 
+import { Observable } from 'rxjs';
+
+
+export interface LoyaltyLevel {
+  level_name: string;
+  points_required: number;
+  reward_description: string;
+}
 @Injectable({ providedIn: 'root' })
 export class ShopService {
+  // inject firestore
+  private firestore = inject(Firestore);
+
+  // Local storage
   setLocal(key: string, value: string): void {
     localStorage.setItem(key, value);
   }
@@ -13,4 +27,10 @@ export class ShopService {
   clearLocal(key: string): void {
     localStorage.removeItem(key);
   }
+  // Loyalty levels from firestore
+  readonly loyaltyLevels = toSignal(
+    collectionData(collection(this.firestore, 'loyalty_levels'), {
+      idField: 'id' // Optional: remove if you don’t need Firestore doc IDs
+    }) as Observable<LoyaltyLevel[]>
+  );
 }

--- a/sprinkle-sprite/src/app/sharedservices/shop.service.ts
+++ b/sprinkle-sprite/src/app/sharedservices/shop.service.ts
@@ -1,4 +1,4 @@
-import { Injectable, inject, signal } from '@angular/core';
+import { Injectable, inject} from '@angular/core';
 import { Firestore, collection, collectionData } from '@angular/fire/firestore';
 import { toSignal } from '@angular/core/rxjs-interop';
 
@@ -30,7 +30,7 @@ export class ShopService {
   // Loyalty levels from firestore
   readonly loyaltyLevels = toSignal(
     collectionData(collection(this.firestore, 'loyalty_levels'), {
-      idField: 'id' // Optional: remove if you don’t need Firestore doc IDs
+      idField: 'id'
     }) as Observable<LoyaltyLevel[]>
   );
 }


### PR DESCRIPTION
📁 Created /rewards folder and routed /vip-rewards to a new POV

🔁 Set up routing from account page → VIP, and VIP → /menu

🔥 Injected Firestore into ShopService for global use

🧠 Pulled and exposed loyaltyLevels and rarities as signals

🔽 Added computed signals for sortedRarities and sortedLoyaltyLevels (XP order)

🎨 Designed full rewards POV: rarity XP chart, loyalty level cards, "how to earn" guide, and call to action

🧱 Used 8-bit pixel card styles to match existing UI theme

🧼 Fixed CSS layout issues and cleaned up component display